### PR TITLE
IEV22 handling errors consultation of publication queues

### DIFF
--- a/src/pages/queues/outlets/queuesInProgress/index.tsx
+++ b/src/pages/queues/outlets/queuesInProgress/index.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
 
 import { queuesInProgressForUser } from "@services/getQueuesInProgress";
 import {
@@ -25,8 +24,6 @@ function QueuesInProgress() {
   });
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const navigate = useNavigate();
-
   const handleOrderData = () => {
     setOrderAscending(!orderAscending);
     orderData(queues, orderAscending);
@@ -37,10 +34,7 @@ function QueuesInProgress() {
     if (queues.length === 0) {
       setLoading(true);
       try {
-        const newQueues = await queuesInProgressForUser(
-          navigate,
-          setErrorMessage
-        );
+        const newQueues = await queuesInProgressForUser(setErrorMessage);
         setQueues(newQueues);
       } catch (error) {
         console.error("Error durante la validación de las colas:", error);

--- a/src/pages/queues/outlets/queuesInProgress/index.tsx
+++ b/src/pages/queues/outlets/queuesInProgress/index.tsx
@@ -33,38 +33,17 @@ function QueuesInProgress() {
     setQueues(queues);
   };
 
-  interface ResponseError extends Error {
-    response?: {
-      status: number;
-      statusText: string;
-    };
-  }
-
   const validateQueues = async () => {
     if (queues.length === 0) {
       setLoading(true);
       try {
-        const newQueues = await queuesInProgressForUser();
+        const newQueues = await queuesInProgressForUser(
+          navigate,
+          setErrorMessage
+        );
         setQueues(newQueues);
       } catch (error) {
-        if (error instanceof Error) {
-          const responseError = error as ResponseError;
-          if (responseError.response) {
-            console.log(
-              `Error: ${responseError.response.status} - ${responseError.response.statusText}`
-            );
-            setErrorMessage(
-              `Error: ${responseError.response.status} - ${responseError.response.statusText}`
-            );
-          } else {
-            console.log("Error:", responseError.message);
-            setErrorMessage(responseError.message);
-          }
-        } else {
-          console.log("Unexpected error:", error);
-          setErrorMessage(`Unexpected error: ${error}`);
-        }
-        navigate("/service-error");
+        console.error("Error durante la validación de las colas:", error);
       } finally {
         setLoading(false);
       }

--- a/src/services/getQueuesInProgress/index.ts
+++ b/src/services/getQueuesInProgress/index.ts
@@ -2,10 +2,11 @@ import { IPublication } from "@pages/queues/outlets/queuesInProgress/types";
 import { enviroment } from "@src/config/environment";
 import { mapQueuesApiToEntities } from "./mappers";
 
-interface FetchError extends Error {
+type FetchError = {
+  message: string;
   status?: number;
-  data?: unknown;
-}
+  name?: string;
+};
 
 const queuesInProgressForUser = async (
   navigate: (path: string) => void,
@@ -34,9 +35,7 @@ const queuesInProgressForUser = async (
       };
 
       const res = await fetch(
-        `${
-          enviroment.ICLIENT_API_URL_QUERY
-        }/publications-queues?${queryParams.toString()}`,
+        `${enviroment.ICLIENT_API_URL_QUERY}/publications-queues?${queryParams.toString()}`,
         options
       );
 
@@ -71,7 +70,9 @@ const queuesInProgressForUser = async (
         const errorMessage = `${fetchError.status} - ${fetchError.message || "Error desconocido"}`;
         setErrorMessage(errorMessage);
       } else {
-        setErrorMessage(`Error desconocido: ${fetchError.message || error}`);
+        setErrorMessage(
+          `Error desconocido: ${fetchError.message || fetchError}`
+        );
       }
 
       if (attempt === maxRetries) {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
- The error handling functionality was adjusted and the logic was moved so that on the localhost if the VPN is not activated it redirects to the service-error page and if the VPN is active but some other error occurs it displays it on the screen through a Flag component.

- The vercel.json configuration file was also created to avoid the 404 error as in Crediboard